### PR TITLE
v2.7.0.Beta2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
     <a href="https://nacos.io/zh-cn/index.html" target="_blank"><img src="https://shields.io/badge/Nacos-2.0.3-brightgreen" alt="Nacos 2.0.3"></a>
     <a href="./LICENSE"><img src="https://shields.io/badge/License-Apache--2.0-blue" alt="License Apache 2.0"></a>
     <a href="https://blog.csdn.net/Pointer_v" target="_blank"><img src="https://shields.io/badge/Author-%E7%A0%81%E5%8C%A0%E5%90%9B-orange" alt="码匠君"></a>
-    <a href="#" target="_blank"><img src="https://shields.io/badge/Version-2.7.0.Beta1-red" alt="Version 2.7.0.Beta1"></a>
+    <a href="#" target="_blank"><img src="https://shields.io/badge/Version-2.7.0.Beta2-red" alt="Version 2.7.0.Beta2"></a>
 </p>
 
 <p align="center">
@@ -51,7 +51,7 @@
 ## 工程结构
 
 ```
-eurynome-cloud
+herodotus-engine
 ├── dependencies -- 工程Maven顶级依赖，统一控制版本和依赖
 ├── documents -- 需要放置的文档位置
 ├    └── readme -- README 相关素材放置目录
@@ -147,7 +147,7 @@ eurynome-cloud
 
 ### 二、独立性阅读
 
-很多组件都是相对独立的，组件间的关联性非常弱。可分开独立阅读和了解代码：
+部分组件都是相对独立的，组件间的关联性非常弱。可分开独立阅读和了解代码：
 
 * engine-captcha
 * engine-oss

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -38,7 +38,7 @@
 
     <groupId>cn.herodotus.engine</groupId>
     <artifactId>dependencies</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>pom</packaging>
 
     <description>Herodotus Dependencies</description>
@@ -93,19 +93,20 @@
 
     <properties>
         <!--Spring 家族-->
+        <spring-boot-admin.version>2.6.2</spring-boot-admin.version>
         <spring-boot-dependencies.version>2.6.3</spring-boot-dependencies.version>
         <spring-cloud-dependencies.version>2021.0.0</spring-cloud-dependencies.version>
         <spring-cloud-alibaba-dependencies.version>2021.1</spring-cloud-alibaba-dependencies.version>
-        <spring-boot-admin.version>2.6.2</spring-boot-admin.version>
         <spring-security-oauth2.version>2.3.4.RELEASE</spring-security-oauth2.version>
+        <spring-security-oauth2-authorization-server.version>0.2.2</spring-security-oauth2-authorization-server.version>
 
         <!--Maven Plugin 相关组件-->
+        <archetype-packaging.verison>3.2.1</archetype-packaging.verison>
         <docker-maven-plugin.version>0.39.0</docker-maven-plugin.version>
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
         <mapstruct-processor.version>1.4.2.Final</mapstruct-processor.version>
         <maven-archetype-plugin.version>3.2.1</maven-archetype-plugin.version>
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
-        <archetype-packaging.verison>3.2.1</archetype-packaging.verison>
         <maven-embedder.version>3.8.4</maven-embedder.version>
         <maven-compat.version>3.8.4</maven-compat.version>
         <maven-invoker.verison>3.1.0</maven-invoker.verison>
@@ -196,6 +197,11 @@
                 <groupId>de.codecentric</groupId>
                 <artifactId>spring-boot-admin-starter-server</artifactId>
                 <version>${spring-boot-admin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-oauth2-authorization-server</artifactId>
+                <version>${spring-security-oauth2-authorization-server.version}</version>
             </dependency>
 
             <!-- Herodotus Engine -->

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -1079,7 +1079,6 @@
                     <version>${maven-gpg-plugin.version}</version>
                     <executions>
                         <execution>
-                            <id>ossrh</id>
                             <phase>verify</phase>
                             <goals>
                                 <goal>sign</goal>

--- a/engine-assistant/assistant-core/pom.xml
+++ b/engine-assistant/assistant-core/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-assistant</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>assistant-core</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-assistant/assistant-sdk-jackson/pom.xml
+++ b/engine-assistant/assistant-sdk-jackson/pom.xml
@@ -30,12 +30,12 @@
     <parent>
         <artifactId>engine-assistant</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>assistant-sdk-jackson</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-assistant/assistant-sdk-secure/pom.xml
+++ b/engine-assistant/assistant-sdk-secure/pom.xml
@@ -30,12 +30,12 @@
     <parent>
         <artifactId>engine-assistant</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>assistant-sdk-secure</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-assistant/assistant-spring-boot-starter/pom.xml
+++ b/engine-assistant/assistant-spring-boot-starter/pom.xml
@@ -30,12 +30,12 @@
     <parent>
         <artifactId>engine-assistant</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>assistant-spring-boot-starter</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-assistant/pom.xml
+++ b/engine-assistant/pom.xml
@@ -38,11 +38,11 @@
     <parent>
         <artifactId>herodotus-engine</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>engine-assistant</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/engine-cache/cache-core/pom.xml
+++ b/engine-cache/cache-core/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-cache</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>cache-core</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-cache/cache-layer-spring-boot-starter/pom.xml
+++ b/engine-cache/cache-layer-spring-boot-starter/pom.xml
@@ -30,12 +30,12 @@
     <parent>
         <artifactId>engine-cache</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>cache-layer-spring-boot-starter</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-cache/cache-sdk-jetcache/pom.xml
+++ b/engine-cache/cache-sdk-jetcache/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-cache</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>cache-sdk-jetcache</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-cache/cache-sdk-layer/pom.xml
+++ b/engine-cache/cache-sdk-layer/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-cache</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>cache-sdk-layer</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-cache/cache-sdk-redisson/pom.xml
+++ b/engine-cache/cache-sdk-redisson/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-cache</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>cache-sdk-redisson</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-cache/cache-spring-boot-starter/pom.xml
+++ b/engine-cache/cache-spring-boot-starter/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-cache</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>cache-spring-boot-starter</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-cache/pom.xml
+++ b/engine-cache/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>herodotus-engine</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>engine-cache</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/engine-captcha/captcha-core/pom.xml
+++ b/engine-captcha/captcha-core/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-captcha</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>captcha-core</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-captcha/captcha-sdk-behavior/pom.xml
+++ b/engine-captcha/captcha-sdk-behavior/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-captcha</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>captcha-sdk-behavior</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-captcha/captcha-sdk-graphic/pom.xml
+++ b/engine-captcha/captcha-sdk-graphic/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-captcha</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>captcha-sdk-graphic</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-captcha/captcha-sdk-hutool/pom.xml
+++ b/engine-captcha/captcha-sdk-hutool/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-captcha</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>captcha-sdk-hutool</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-captcha/captcha-spring-boot-starter/pom.xml
+++ b/engine-captcha/captcha-spring-boot-starter/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-captcha</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>captcha-spring-boot-starter</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-captcha/pom.xml
+++ b/engine-captcha/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>herodotus-engine</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/engine-data/data-core/pom.xml
+++ b/engine-data/data-core/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-data</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>data-core</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-data/data-sdk-jpa/pom.xml
+++ b/engine-data/data-sdk-jpa/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-data</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>data-sdk-jpa</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-data/data-sdk-jpa/src/main/java/cn/herodotus/engine/data/jpa/hibernate/postgresql/HerodotusPostgreSQLDialect.java
+++ b/engine-data/data-sdk-jpa/src/main/java/cn/herodotus/engine/data/jpa/hibernate/postgresql/HerodotusPostgreSQLDialect.java
@@ -25,7 +25,10 @@
 
 package cn.herodotus.engine.data.jpa.hibernate.postgresql;
 
-import org.hibernate.dialect.PostgreSQL9Dialect;
+import org.hibernate.dialect.PostgreSQL10Dialect;
+import org.hibernate.type.descriptor.sql.LongVarbinaryTypeDescriptor;
+import org.hibernate.type.descriptor.sql.LongVarcharTypeDescriptor;
+import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
 
 import java.sql.Types;
 
@@ -35,7 +38,7 @@ import java.sql.Types;
  * @author : gengwei.zheng
  * @date : 2019/11/15 10:31
  */
-public class HerodotusPostgreSQLDialect extends PostgreSQL9Dialect {
+public class HerodotusPostgreSQLDialect extends PostgreSQL10Dialect {
 
     public HerodotusPostgreSQLDialect() {
         super();
@@ -43,19 +46,43 @@ public class HerodotusPostgreSQLDialect extends PostgreSQL9Dialect {
         this.registerColumnType(Types.ARRAY, "text[]");
     }
 
+//    /**
+//     * 重载getAddForeignKeyConstraintString方法，阻止ddl-auto添加外键关联
+//     *
+//     * @param constraintName
+//     * @param foreignKey
+//     * @param referencedTable
+//     * @param primaryKey
+//     * @param referencesPrimaryKey
+//     * @return String
+//     */
+//    @Override
+//    public String getAddForeignKeyConstraintString(String constraintName, String[] foreignKey, String referencedTable, String[] primaryKey, boolean referencesPrimaryKey) {
+//        //  设置foreignkey对应的列值可以为空
+//        return " alter " + foreignKey[0] + " set default null ";
+//    }
+
+
     /**
-     * 重载getAddForeignKeyConstraintString方法，阻止ddl-auto添加外键关联
+     * 在 JPA 环境下，映射 PostgreSQL TEXT 专有类型的三种处理方式中的一种。
+     * <p>
+     * 这个方法将 @Lob 对应的 CLOB 和 BLOB 合并进行了处理
      *
-     * @param constraintName
-     * @param foreignKey
-     * @param referencedTable
-     * @param primaryKey
-     * @param referencesPrimaryKey
-     * @return String
+     * @param sqlTypeDescriptor SQL 类型描述器
+     * @return 处理后的 SQL 类型描述器
+     * @see <a href="https://www.baeldung.com/jpa-annotation-postgresql-text-type">参考资料1</a>
+     * @see <a href="https://blog.csdn.net/weixin_30539835/article/details/98190592">参考资料2</a>
+     * @see <a href="https://stackoverflow.com/questions/13090089/org-hibernate-type-texttype-and-oracle">参考资料3</a>
+     * @see <a href="https://www.programminghunter.com/article/2482653094/">参考资料4</a>
      */
     @Override
-    public String getAddForeignKeyConstraintString(String constraintName, String[] foreignKey, String referencedTable, String[] primaryKey, boolean referencesPrimaryKey) {
-        //  设置foreignkey对应的列值可以为空
-        return " alter " + foreignKey[0] + " set default null ";
+    public SqlTypeDescriptor remapSqlTypeDescriptor(SqlTypeDescriptor sqlTypeDescriptor) {
+        switch (sqlTypeDescriptor.getSqlType()) {
+            case Types.CLOB:
+                return LongVarcharTypeDescriptor.INSTANCE;
+            case Types.BLOB:
+                return LongVarbinaryTypeDescriptor.INSTANCE;
+        }
+        return super.remapSqlTypeDescriptor(sqlTypeDescriptor);
     }
 }

--- a/engine-data/data-sdk-mybatis-plus/pom.xml
+++ b/engine-data/data-sdk-mybatis-plus/pom.xml
@@ -30,12 +30,12 @@
     <parent>
         <artifactId>engine-data</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>data-sdk-mybatis-plus</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-data/data-sdk-p6spy/pom.xml
+++ b/engine-data/data-sdk-p6spy/pom.xml
@@ -32,12 +32,12 @@
     <parent>
         <artifactId>engine-data</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
 
     <artifactId>data-sdk-p6spy</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-data/data-spring-boot-starter/pom.xml
+++ b/engine-data/data-spring-boot-starter/pom.xml
@@ -30,12 +30,12 @@
     <parent>
         <artifactId>engine-data</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>data-spring-boot-starter</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-data/pom.xml
+++ b/engine-data/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>herodotus-engine</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/engine-event/event-core-local/pom.xml
+++ b/engine-event/event-core-local/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-event</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>event-core-local</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-event/event-core-remote/pom.xml
+++ b/engine-event/event-core-remote/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-event</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>event-core-remote</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-event/event-pay-spring-boot-starter/pom.xml
+++ b/engine-event/event-pay-spring-boot-starter/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-event</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>event-pay-spring-boot-starter</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-event/event-sdk-pay/pom.xml
+++ b/engine-event/event-sdk-pay/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-event</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>event-sdk-pay</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-event/event-sdk-security/pom.xml
+++ b/engine-event/event-sdk-security/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-event</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>event-sdk-security</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-event/event-security-spring-boot-starter/pom.xml
+++ b/engine-event/event-security-spring-boot-starter/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-event</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>event-security-spring-boot-starter</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-event/pom.xml
+++ b/engine-event/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>herodotus-engine</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>engine-event</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/engine-facility/facility-core/pom.xml
+++ b/engine-facility/facility-core/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-facility</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>facility-core</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-facility/facility-sdk-log/pom.xml
+++ b/engine-facility/facility-sdk-log/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-facility</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>facility-sdk-log</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-facility/facility-sdk-sentinel/pom.xml
+++ b/engine-facility/facility-sdk-sentinel/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-facility</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>facility-sdk-sentinel</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-facility/facility-spring-boot-starter/pom.xml
+++ b/engine-facility/facility-spring-boot-starter/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <artifactId>engine-facility</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>facility-spring-boot-starter</artifactId>

--- a/engine-facility/pom.xml
+++ b/engine-facility/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>herodotus-engine</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>engine-facility</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/engine-message/message-core/pom.xml
+++ b/engine-message/message-core/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-message</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>message-core</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-message/message-spring-boot-starter/pom.xml
+++ b/engine-message/message-spring-boot-starter/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-message</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>message-spring-boot-starter</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-message/pom.xml
+++ b/engine-message/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>herodotus-engine</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>engine-message</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/engine-oss/oss-core/pom.xml
+++ b/engine-oss/oss-core/pom.xml
@@ -33,11 +33,11 @@
     <parent>
         <artifactId>engine-oss</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>oss-core</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-oss/oss-sdk-minio/pom.xml
+++ b/engine-oss/oss-sdk-minio/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-oss</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>oss-sdk-minio</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-oss/oss-spring-boot-starter/pom.xml
+++ b/engine-oss/oss-spring-boot-starter/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-oss</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>oss-spring-boot-starter</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-oss/pom.xml
+++ b/engine-oss/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>herodotus-engine</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/engine-pay/pay-core/pom.xml
+++ b/engine-pay/pay-core/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-pay</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>pay-core</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-pay/pay-sdk-alipay/pom.xml
+++ b/engine-pay/pay-sdk-alipay/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-pay</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>pay-sdk-alipay</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-pay/pay-sdk-all/pom.xml
+++ b/engine-pay/pay-sdk-all/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-pay</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>pay-sdk-all</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-pay/pay-sdk-wxpay/pom.xml
+++ b/engine-pay/pay-sdk-wxpay/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-pay</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>pay-sdk-wxpay</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-pay/pay-spring-boot-starter/pom.xml
+++ b/engine-pay/pay-spring-boot-starter/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-pay</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>pay-spring-boot-starter</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-pay/pom.xml
+++ b/engine-pay/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>herodotus-engine</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/engine-rest/pom.xml
+++ b/engine-rest/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>herodotus-engine</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/engine-rest/rest-core/pom.xml
+++ b/engine-rest/rest-core/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-rest</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>rest-core</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-rest/rest-sdk-crypto/pom.xml
+++ b/engine-rest/rest-sdk-crypto/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-rest</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>rest-sdk-crypto</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-rest/rest-sdk-secure/pom.xml
+++ b/engine-rest/rest-sdk-secure/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-rest</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>rest-sdk-secure</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-rest/rest-spring-boot-starter/pom.xml
+++ b/engine-rest/rest-spring-boot-starter/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-rest</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>rest-spring-boot-starter</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-security/pom.xml
+++ b/engine-security/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>herodotus-engine</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>engine-security</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/engine-security/security-core/pom.xml
+++ b/engine-security/security-core/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-security</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>security-core</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-security/security-sdk-authorize/pom.xml
+++ b/engine-security/security-sdk-authorize/pom.xml
@@ -30,12 +30,12 @@
     <parent>
         <artifactId>engine-security</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>security-sdk-authorize</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
    <dependencies>

--- a/engine-security/security-sdk-extend/pom.xml
+++ b/engine-security/security-sdk-extend/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-security</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>security-sdk-extend</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-security/security-sdk-extend/src/main/java/cn/herodotus/engine/security/extend/enhance/HerodotusUserAuthenticationConverter.java
+++ b/engine-security/security-sdk-extend/src/main/java/cn/herodotus/engine/security/extend/enhance/HerodotusUserAuthenticationConverter.java
@@ -92,8 +92,8 @@ public class HerodotusUserAuthenticationConverter extends DefaultUserAuthenticat
     /**
      * 读取认证信息
      *
-     * @param map
-     * @return
+     * @param map 认证信息存储对象
+     * @return OAuth2 认证对象
      */
     @Override
     public Authentication extractAuthentication(Map<String, ?> map) {

--- a/engine-security/security-sdk-log/pom.xml
+++ b/engine-security/security-sdk-log/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-security</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>security-sdk-log</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-temporal/pom.xml
+++ b/engine-temporal/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>herodotus-engine</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/engine-temporal/temporal-core/pom.xml
+++ b/engine-temporal/temporal-core/pom.xml
@@ -30,12 +30,12 @@
     <parent>
         <artifactId>engine-temporal</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>temporal-core</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-temporal/temporal-sdk-influxdb/pom.xml
+++ b/engine-temporal/temporal-sdk-influxdb/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-temporal</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>temporal-sdk-influxdb</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-temporal/temporal-spring-boot-starter/pom.xml
+++ b/engine-temporal/temporal-spring-boot-starter/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-temporal</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>temporal-spring-boot-starter</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-web/pom.xml
+++ b/engine-web/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>herodotus-engine</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>engine-web</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/engine-web/web-core/pom.xml
+++ b/engine-web/web-core/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>engine-web</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/engine-web/web-core/src/main/java/cn/herodotus/engine/web/core/utils/WebUtils.java
+++ b/engine-web/web-core/src/main/java/cn/herodotus/engine/web/core/utils/WebUtils.java
@@ -141,9 +141,8 @@ public class WebUtils extends org.springframework.web.util.WebUtils {
     /**
      * 客户端返回JSON字符串
      *
-     * @param response
-     * @param object
-     * @return
+     * @param response HttpServletResponse
+     * @param object   需要转换的对象
      */
     public static void renderJson(HttpServletResponse response, Object object) {
         renderJson(response, JSON.toJSONString(object), MediaType.APPLICATION_JSON.toString());
@@ -152,9 +151,8 @@ public class WebUtils extends org.springframework.web.util.WebUtils {
     /**
      * 客户端返回字符串
      *
-     * @param response
-     * @param string
-     * @return
+     * @param response HttpServletResponse
+     * @param string   需要绘制的信息
      */
     public static void renderJson(HttpServletResponse response, String string, String type) {
         try {

--- a/engine-web/web-sdk-rest/pom.xml
+++ b/engine-web/web-sdk-rest/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-web</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>web-sdk-rest</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-web/web-sdk-scan/pom.xml
+++ b/engine-web/web-sdk-scan/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-web</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>web-sdk-scan</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-web/web-spring-boot-starter/pom.xml
+++ b/engine-web/web-spring-boot-starter/pom.xml
@@ -30,12 +30,12 @@
     <parent>
         <artifactId>engine-web</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>web-spring-boot-starter</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-websocket/pom.xml
+++ b/engine-websocket/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>herodotus-engine</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/engine-websocket/websocket-core/pom.xml
+++ b/engine-websocket/websocket-core/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-websocket</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>websocket-core</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-websocket/websocket-sdk-accelerator/pom.xml
+++ b/engine-websocket/websocket-sdk-accelerator/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-websocket</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>websocket-sdk-accelerator</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/engine-websocket/websocket-spring-boot-starter/pom.xml
+++ b/engine-websocket/websocket-spring-boot-starter/pom.xml
@@ -32,11 +32,11 @@
     <parent>
         <artifactId>engine-websocket</artifactId>
         <groupId>cn.herodotus.engine</groupId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
     </parent>
 
     <artifactId>websocket-spring-boot-starter</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -33,12 +33,12 @@
     <parent>
         <groupId>cn.herodotus.engine</groupId>
         <artifactId>dependencies</artifactId>
-        <version>2.7.0.Beta1</version>
+        <version>2.7.0.Beta2</version>
         <relativePath>dependencies/pom.xml</relativePath>
     </parent>
 
     <artifactId>herodotus-engine</artifactId>
-    <version>2.7.0.Beta1</version>
+    <version>2.7.0.Beta2</version>
     <packaging>pom</packaging>
 
     <description>Herodotus Engine</description>


### PR DESCRIPTION
1. 更正工程 Readme 文档表述错误内容。
2. 优化自定义 Hibernate Dialect，增加 PostgreSQL 环境下对 CLOB 和 BLOB 数据类型的统一支持。为 Spring Authorization Server 的使用奠定基础
3. 完善大量 Herodotus Engine 代码中的注释内容，解决代码编译生成 Javadoc 显示大量告警信息问题。
4. 由于使用组件库的方式，源代码包和 Javadoc 包均已生成。已有微服务工程无须再进行源代码的编译，因此去掉 Eurynome Cloud 主工程源代码编译配置和相关依赖。